### PR TITLE
Add `filter` command to filter person list items

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -217,6 +217,16 @@ _{more aspects and alternatives to be added}_
 
 _{Explain here how the data archiving feature will be implemented}_
 
+### Filtering PersonCard
+
+Current implementation is to add a new Predicate that is added in Model.
+When the FilterCommand is executed, Model will be updated with the latest display filter.
+
+Since execution of FilterCommand happens in MainWindow, MainWindow will then pass the predicate down
+to PersonListPanel which then trigger ListView to be re-drawn. During the creation of a PersonCard,
+the fields that are not to be shown will have visibility set to false and will not be managed by the
+parent. This is done so that the dimension of the hidden field will not be included during the
+layoutBounds calculations.
 
 --------------------------------------------------------------------------------------------------------------------
 

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -206,34 +206,29 @@ Examples:
 |`unalias ls`| will remove the alias `ls`|
 |`unalias d`| will remove the alias `d`| -->
 
-### List options [coming soon]
+### Filter
 
-<!-- List options provide the user with the choice to tweak their list return result according to the specified option(s).
+Filter provides the user with the choice to tweak their result display according to the specified option(s).
 
-Format: each option should start with OPTION/ and be separated by a whitespace, where OPTION/ refers to the option Key.
-ie. `list [OPTION_1/ OPTION_2/ … OPTION_N/]`
+Format: `list [-OPTION] [-OPTION1]...`
+
+each option should start with a hyphen `-` e.g. `-OPTION` and be separated by a whitespace.
 
 Key:
+
 | Key | Description |
 | --------------- | -------- |
-|`n`|    Name|
 |`p`|     Phone number|
 |`e`|    Email|
 |`a`|    Address|
 |`t`|    Tag|
-|`b` |   Birthday (new)|
-|`g` |   Gender (new) |
-|`no`|    Notes (new) |
 
 Examples:
+
 | Example | Description |
 | --------------- | -------- |
-|`list -n `| returns the list of all contacts with name as the only field.|
-|`list -n -b -g`| returns the list of all contacts with name, birthday, gender as the only fields.|
-
-Tip:
-Combine the Alias feature with custom options to have a customized view. E.g. `alias list=”list -n  -p  -e  -t ` to only show the name, phone number, email and tags. -->
-
+|`list -a `| show the contact's name and address only.|
+|`list -a -p`| show the contact's name, address and phone number only.|
 
 ### Saving the data
 
@@ -265,6 +260,7 @@ Action | Format, Examples
 **Delete** | `delete INDEX`<br> e.g., `delete 3`
 **Edit** | `edit INDEX [-n NAME] [-p PHONE_NUMBER] [-e EMAIL] [-a ADDRESS] [-t TAG]…​`<br> e.g.,`edit 2 -n James Lee -e jameslee@example.com`
 **Find** | `find KEYWORD [MORE_KEYWORDS]`<br> e.g., `find James Jake`
+**Filter** | `filter [-p] [-e] [-a] [-t]` <br> e.g., `filter -p -a` to see only the phone number and address
 **List** | `list`
 **Help** | `help`
 **Alias** | _[coming soon]_

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -1,11 +1,13 @@
 package seedu.address.logic;
 
 import java.nio.file.Path;
+import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
@@ -47,4 +49,10 @@ public interface Logic {
      * Set the user prefs' GUI settings.
      */
     void setGuiSettings(GuiSettings guiSettings);
+
+    /**
+     * Returns the predicate for display filtering.
+     * @return predicate that returns true if prefix linked control should be hidden
+     */
+    Predicate<Prefix> getDisplayFilter();
 }

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -50,8 +50,8 @@ public interface Logic {
     void setGuiSettings(GuiSettings guiSettings);
 
     /**
-     * Returns the predicate for display filtering.
-     * @return predicate that returns true if prefix linked control should be hidden
+     * Returns predicate that determines field control visibility.
+     * @return predicate that returns true if prefix linked control should be shown
      */
     DisplayFilterPredicate getDisplayFilter();
 }

--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -1,14 +1,13 @@
 package seedu.address.logic;
 
 import java.nio.file.Path;
-import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.DisplayFilterPredicate;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
 
@@ -54,5 +53,5 @@ public interface Logic {
      * Returns the predicate for display filtering.
      * @return predicate that returns true if prefix linked control should be hidden
      */
-    Predicate<Prefix> getDisplayFilter();
+    DisplayFilterPredicate getDisplayFilter();
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -2,7 +2,6 @@ package seedu.address.logic;
 
 import java.io.IOException;
 import java.nio.file.Path;
-import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
@@ -12,8 +11,8 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.AddressBookParser;
-import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.DisplayFilterPredicate;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
@@ -23,6 +22,7 @@ import seedu.address.storage.Storage;
  * The main LogicManager of the app.
  */
 public class LogicManager implements Logic {
+
     public static final String FILE_OPS_ERROR_MESSAGE = "Could not save data to file: ";
     private final Logger logger = LogsCenter.getLogger(LogicManager.class);
 
@@ -82,7 +82,7 @@ public class LogicManager implements Logic {
     }
 
     @Override
-    public Predicate<Prefix> getDisplayFilter() {
+    public DisplayFilterPredicate getDisplayFilter() {
         return model.getDisplayFilter();
     }
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -2,6 +2,7 @@ package seedu.address.logic;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
@@ -11,6 +12,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.AddressBookParser;
+import seedu.address.logic.parser.Prefix;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
@@ -77,5 +79,10 @@ public class LogicManager implements Logic {
     @Override
     public void setGuiSettings(GuiSettings guiSettings) {
         model.setGuiSettings(guiSettings);
+    }
+
+    @Override
+    public Predicate<Prefix> getDisplayFilter() {
+        return model.getDisplayFilter();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -1,0 +1,37 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOULD_NOT_HIDE;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.model.Model;
+
+/**
+ * Sets the person list filter.
+ */
+public class FilterCommand extends Command {
+
+    public static final String COMMAND_WORD = "filter";
+
+    public static final String MESSAGE_SUCCESS = "Applied filter";
+
+    private final ArgumentMultimap filterArguments;
+
+    public FilterCommand(ArgumentMultimap filterArguments) {
+        this.filterArguments = filterArguments;
+    }
+
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+
+        if (filterArguments.getArgumentSize() == 1) {
+            model.updateDisplayFilter(PREDICATE_SHOULD_NOT_HIDE);
+        } else {
+            model.updateDisplayFilter(prefix -> filterArguments.getValue(prefix).isPresent());
+        }
+        return new CommandResult(
+                String.format(MESSAGE_SUCCESS));
+    }
+}

--- a/src/main/java/seedu/address/logic/commands/FilterCommand.java
+++ b/src/main/java/seedu/address/logic/commands/FilterCommand.java
@@ -1,10 +1,9 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.model.Model.PREDICATE_SHOULD_NOT_HIDE;
 
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.model.DisplayFilterPredicate;
 import seedu.address.model.Model;
 
 /**
@@ -16,22 +15,24 @@ public class FilterCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "Applied filter";
 
-    private final ArgumentMultimap filterArguments;
+    private final DisplayFilterPredicate filterPredicate;
 
-    public FilterCommand(ArgumentMultimap filterArguments) {
-        this.filterArguments = filterArguments;
+    public FilterCommand(DisplayFilterPredicate filterPredicate) {
+        this.filterPredicate = filterPredicate;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
 
-        if (filterArguments.getArgumentSize() == 1) {
-            model.updateDisplayFilter(PREDICATE_SHOULD_NOT_HIDE);
-        } else {
-            model.updateDisplayFilter(prefix -> filterArguments.getValue(prefix).isPresent());
-        }
-        return new CommandResult(
-                String.format(MESSAGE_SUCCESS));
+        model.updateDisplayFilter(filterPredicate);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof FilterCommand) // instanceof handles nulls
+                && filterPredicate.equals(((FilterCommand) other).filterPredicate);
     }
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -12,6 +12,7 @@ import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
@@ -61,6 +62,9 @@ public class AddressBookParser {
 
         case ListCommand.COMMAND_WORD:
             return new ListCommand();
+
+        case FilterCommand.COMMAND_WORD:
+            return new FilterCommandParser().parse(arguments);
 
         case ExitCommand.COMMAND_WORD:
             return new ExitCommand();

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -60,6 +60,7 @@ public class ArgumentMultimap {
 
     /**
      * Returns the number of arguments.
+     * @return Map size
      */
     public int getArgumentSize() {
         return argMultimap.size();

--- a/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
+++ b/src/main/java/seedu/address/logic/parser/ArgumentMultimap.java
@@ -57,4 +57,11 @@ public class ArgumentMultimap {
     public String getPreamble() {
         return getValue(new Prefix("")).orElse("");
     }
+
+    /**
+     * Returns the number of arguments.
+     */
+    public int getArgumentSize() {
+        return argMultimap.size();
+    }
 }

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -1,0 +1,28 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import seedu.address.logic.commands.FilterCommand;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new FilterCommand object
+ */
+public class FilterCommandParser implements Parser<FilterCommand> {
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the FilterCommand and returns
+     * an FilterCommand object for execution.
+     *
+     * @throws ParseException if the user input does not conform the expected format
+     */
+    @Override
+    public FilterCommand parse(String args) throws ParseException {
+        ArgumentMultimap argMultimap = ArgumentTokenizer
+                .tokenize(args, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+        return new FilterCommand(argMultimap);
+    }
+}

--- a/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/FilterCommandParser.java
@@ -7,6 +7,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
 import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.DisplayFilterPredicate;
 
 /**
  * Parses input arguments and creates a new FilterCommand object
@@ -21,8 +22,12 @@ public class FilterCommandParser implements Parser<FilterCommand> {
      */
     @Override
     public FilterCommand parse(String args) throws ParseException {
+        if (args.isEmpty()) {
+            return new FilterCommand(new DisplayFilterPredicate());
+        }
         ArgumentMultimap argMultimap = ArgumentTokenizer
                 .tokenize(args, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
-        return new FilterCommand(argMultimap);
+
+        return new FilterCommand(new DisplayFilterPredicate(argMultimap));
     }
 }

--- a/src/main/java/seedu/address/model/DisplayFilterPredicate.java
+++ b/src/main/java/seedu/address/model/DisplayFilterPredicate.java
@@ -1,0 +1,61 @@
+package seedu.address.model;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import java.util.HashMap;
+import java.util.function.Predicate;
+
+import seedu.address.logic.parser.ArgumentMultimap;
+import seedu.address.logic.parser.Prefix;
+
+/**
+ * Tests if a {@code Person}'s field in {@code PersonCard} should be hidden. By default, all the
+ * fields are shown if no {@code ArgumentMultimap} is provided.
+ */
+public class DisplayFilterPredicate implements Predicate<Prefix> {
+
+    private final HashMap<Prefix, Boolean> map;
+
+    /**
+     * Initializes known prefixes to true. See {@code CliSyntax} for known prefixes.
+     */
+    public DisplayFilterPredicate() {
+        map = new HashMap<>();
+        map.put(PREFIX_NAME, true);
+        map.put(PREFIX_PHONE, true);
+        map.put(PREFIX_EMAIL, true);
+        map.put(PREFIX_ADDRESS, true);
+        map.put(PREFIX_TAG, true);
+    }
+
+    /**
+     * Initializes prefixes in argumentMultimap to true if present. See {@code CliSyntax} for known
+     * prefixes.
+     */
+    public DisplayFilterPredicate(ArgumentMultimap argumentMultimap) {
+        this();
+        if (argumentMultimap.getArgumentSize() != 0) {
+            map.put(PREFIX_PHONE, argumentMultimap.getValue(PREFIX_PHONE).isPresent());
+            map.put(PREFIX_EMAIL, argumentMultimap.getValue(PREFIX_EMAIL).isPresent());
+            map.put(PREFIX_ADDRESS, argumentMultimap.getValue(PREFIX_ADDRESS).isPresent());
+            map.put(PREFIX_TAG, argumentMultimap.getValue(PREFIX_TAG).isPresent());
+        }
+    }
+
+    @Override
+    public boolean test(Prefix prefix) {
+        return map.getOrDefault(prefix, true);
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof DisplayFilterPredicate) // instanceof handles nulls
+                && map.keySet().stream()
+                .allMatch(e -> map.get(e).equals(((DisplayFilterPredicate) other).map.get(e)));
+    }
+}

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,7 +5,6 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.logic.parser.Prefix;
 import seedu.address.model.person.Person;
 
 /**
@@ -14,9 +13,6 @@ import seedu.address.model.person.Person;
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
-
-    /** {@code Predicate} that always evaluate to false */
-    Predicate<Prefix> PREDICATE_SHOULD_NOT_HIDE = unused -> true;
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
@@ -91,13 +87,13 @@ public interface Model {
 
     /**
      * Updates the display filter for PersonCard controls.
-     * @param predicate that returns true if prefix linked control should be hidden
+     * @param displayFilterPredicate that returns true if prefix linked control should be hidden
      */
-    void updateDisplayFilter(Predicate<Prefix> predicate);
+    void updateDisplayFilter(DisplayFilterPredicate displayFilterPredicate);
 
     /**
      * Returns the display filter for PersonCard controls.
      * @return predicate that returns true if prefix linked control should be hidden
      */
-    Predicate<Prefix> getDisplayFilter();
+    DisplayFilterPredicate getDisplayFilter();
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -5,6 +5,7 @@ import java.util.function.Predicate;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
+import seedu.address.logic.parser.Prefix;
 import seedu.address.model.person.Person;
 
 /**
@@ -13,6 +14,9 @@ import seedu.address.model.person.Person;
 public interface Model {
     /** {@code Predicate} that always evaluate to true */
     Predicate<Person> PREDICATE_SHOW_ALL_PERSONS = unused -> true;
+
+    /** {@code Predicate} that always evaluate to false */
+    Predicate<Prefix> PREDICATE_SHOULD_NOT_HIDE = unused -> true;
 
     /**
      * Replaces user prefs data with the data in {@code userPrefs}.
@@ -84,4 +88,16 @@ public interface Model {
      * @throws NullPointerException if {@code predicate} is null.
      */
     void updateFilteredPersonList(Predicate<Person> predicate);
+
+    /**
+     * Updates the display filter for PersonCard controls.
+     * @param predicate that returns true if prefix linked control should be hidden
+     */
+    void updateDisplayFilter(Predicate<Prefix> predicate);
+
+    /**
+     * Returns the display filter for PersonCard controls.
+     * @return predicate that returns true if prefix linked control should be hidden
+     */
+    Predicate<Prefix> getDisplayFilter();
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,7 +11,6 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.logic.parser.Prefix;
 import seedu.address.model.person.Person;
 
 /**
@@ -23,8 +22,7 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
-
-    private Predicate<Prefix> displayFilter;
+    private DisplayFilterPredicate displayFilterPredicate;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -38,7 +36,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
-        displayFilter = PREDICATE_SHOULD_NOT_HIDE;
+        displayFilterPredicate = new DisplayFilterPredicate();
     }
 
     public ModelManager() {
@@ -134,13 +132,13 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void updateDisplayFilter(Predicate<Prefix> displayFilter) {
-        this.displayFilter = displayFilter;
+    public void updateDisplayFilter(DisplayFilterPredicate displayFilterPredicate) {
+        this.displayFilterPredicate = displayFilterPredicate;
     }
 
     @Override
-    public Predicate<Prefix> getDisplayFilter() {
-        return displayFilter;
+    public DisplayFilterPredicate getDisplayFilter() {
+        return displayFilterPredicate;
     }
 
     @Override

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -11,6 +11,7 @@ import javafx.collections.ObservableList;
 import javafx.collections.transformation.FilteredList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.parser.Prefix;
 import seedu.address.model.person.Person;
 
 /**
@@ -22,6 +23,8 @@ public class ModelManager implements Model {
     private final AddressBook addressBook;
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
+
+    private Predicate<Prefix> displayFilter;
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -35,6 +38,7 @@ public class ModelManager implements Model {
         this.addressBook = new AddressBook(addressBook);
         this.userPrefs = new UserPrefs(userPrefs);
         filteredPersons = new FilteredList<>(this.addressBook.getPersonList());
+        displayFilter = PREDICATE_SHOULD_NOT_HIDE;
     }
 
     public ModelManager() {
@@ -124,9 +128,19 @@ public class ModelManager implements Model {
     }
 
     @Override
-    public void updateFilteredPersonList(Predicate<Person> predicate) {
-        requireNonNull(predicate);
-        filteredPersons.setPredicate(predicate);
+    public void updateFilteredPersonList(Predicate<Person> displayFilter) {
+        requireNonNull(displayFilter);
+        filteredPersons.setPredicate(displayFilter);
+    }
+
+    @Override
+    public void updateDisplayFilter(Predicate<Prefix> displayFilter) {
+        this.displayFilter = displayFilter;
+    }
+
+    @Override
+    public Predicate<Prefix> getDisplayFilter() {
+        return displayFilter;
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -110,7 +110,8 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
-        personListPanel = new PersonListPanel(logic.getFilteredPersonList());
+        personListPanel = new PersonListPanel(logic.getFilteredPersonList(),
+                logic.getDisplayFilter());
         personListPanelPlaceholder.getChildren().add(personListPanel.getRoot());
 
         resultDisplay = new ResultDisplay();
@@ -185,6 +186,8 @@ public class MainWindow extends UiPart<Stage> {
             if (commandResult.isExit()) {
                 handleExit();
             }
+
+            personListPanel.updateDisplayFilter(logic.getDisplayFilter());
 
             return commandResult;
         } catch (CommandException | ParseException e) {

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -1,12 +1,21 @@
 package seedu.address.ui;
 
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
 import java.util.Comparator;
+import java.util.function.Predicate;
 
 import javafx.fxml.FXML;
 import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
+
+import seedu.address.logic.parser.Prefix;
 import seedu.address.model.person.Person;
 
 /**
@@ -44,7 +53,7 @@ public class PersonCard extends UiPart<Region> {
     /**
      * Creates a {@code PersonCode} with the given {@code Person} and index to display.
      */
-    public PersonCard(Person person, int displayedIndex) {
+    public PersonCard(Person person, int displayedIndex, Predicate<Prefix> displayFilter) {
         super(FXML);
         this.person = person;
         id.setText(displayedIndex + ". ");
@@ -55,6 +64,16 @@ public class PersonCard extends UiPart<Region> {
         person.getTags().stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
+
+        // Update control visibility
+        phone.setVisible(displayFilter.test(PREFIX_PHONE));
+        phone.setManaged(displayFilter.test(PREFIX_PHONE));
+        address.setVisible(displayFilter.test(PREFIX_ADDRESS));
+        address.setManaged(displayFilter.test(PREFIX_ADDRESS));
+        email.setVisible(displayFilter.test(PREFIX_EMAIL));
+        email.setManaged(displayFilter.test(PREFIX_EMAIL));
+        tags.setVisible(displayFilter.test(PREFIX_TAG));
+        tags.setManaged(displayFilter.test(PREFIX_TAG));
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/PersonCard.java
+++ b/src/main/java/seedu/address/ui/PersonCard.java
@@ -2,7 +2,6 @@ package seedu.address.ui;
 
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
@@ -14,7 +13,6 @@ import javafx.scene.control.Label;
 import javafx.scene.layout.FlowPane;
 import javafx.scene.layout.HBox;
 import javafx.scene.layout.Region;
-
 import seedu.address.logic.parser.Prefix;
 import seedu.address.model.person.Person;
 
@@ -26,11 +24,12 @@ public class PersonCard extends UiPart<Region> {
     private static final String FXML = "PersonListCard.fxml";
 
     /**
-     * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX.
-     * As a consequence, UI elements' variable names cannot be set to such keywords
-     * or an exception will be thrown by JavaFX during runtime.
+     * Note: Certain keywords such as "location" and "resources" are reserved keywords in JavaFX. As
+     * a consequence, UI elements' variable names cannot be set to such keywords or an exception
+     * will be thrown by JavaFX during runtime.
      *
-     * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on AddressBook level 4</a>
+     * @see <a href="https://github.com/se-edu/addressbook-level4/issues/336">The issue on
+     * AddressBook level 4</a>
      */
 
     public final Person person;

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -1,5 +1,6 @@
 package seedu.address.ui;
 
+import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
@@ -8,6 +9,7 @@ import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
+import seedu.address.logic.parser.Prefix;
 import seedu.address.model.person.Person;
 
 /**
@@ -20,13 +22,21 @@ public class PersonListPanel extends UiPart<Region> {
     @FXML
     private ListView<Person> personListView;
 
+    private Predicate<Prefix> displayFilter;
+
     /**
      * Creates a {@code PersonListPanel} with the given {@code ObservableList}.
      */
-    public PersonListPanel(ObservableList<Person> personList) {
+    public PersonListPanel(ObservableList<Person> personList, Predicate<Prefix> displayFilter) {
         super(FXML);
         personListView.setItems(personList);
         personListView.setCellFactory(listView -> new PersonListViewCell());
+        this.displayFilter = displayFilter;
+    }
+
+    public void updateDisplayFilter(Predicate<Prefix> displayFilter) {
+        this.displayFilter = displayFilter;
+        this.personListView.refresh();
     }
 
     /**
@@ -41,7 +51,7 @@ public class PersonListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new PersonCard(person, getIndex() + 1).getRoot());
+                setGraphic(new PersonCard(person, getIndex() + 1, displayFilter).getRoot());
             }
         }
     }

--- a/src/main/java/seedu/address/ui/PersonListPanel.java
+++ b/src/main/java/seedu/address/ui/PersonListPanel.java
@@ -1,6 +1,5 @@
 package seedu.address.ui;
 
-import java.util.function.Predicate;
 import java.util.logging.Logger;
 
 import javafx.collections.ObservableList;
@@ -9,40 +8,48 @@ import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
 import seedu.address.commons.core.LogsCenter;
-import seedu.address.logic.parser.Prefix;
+import seedu.address.model.DisplayFilterPredicate;
 import seedu.address.model.person.Person;
 
 /**
  * Panel containing the list of persons.
  */
 public class PersonListPanel extends UiPart<Region> {
+
     private static final String FXML = "PersonListPanel.fxml";
     private final Logger logger = LogsCenter.getLogger(PersonListPanel.class);
 
     @FXML
     private ListView<Person> personListView;
 
-    private Predicate<Prefix> displayFilter;
+    private DisplayFilterPredicate displayFilterPredicate;
 
     /**
      * Creates a {@code PersonListPanel} with the given {@code ObservableList}.
      */
-    public PersonListPanel(ObservableList<Person> personList, Predicate<Prefix> displayFilter) {
+    public PersonListPanel(ObservableList<Person> personList,
+            DisplayFilterPredicate displayFilterPredicate) {
         super(FXML);
         personListView.setItems(personList);
         personListView.setCellFactory(listView -> new PersonListViewCell());
-        this.displayFilter = displayFilter;
+        this.displayFilterPredicate = displayFilterPredicate;
     }
 
-    public void updateDisplayFilter(Predicate<Prefix> displayFilter) {
-        this.displayFilter = displayFilter;
+    /**
+     * Updates the filter used for PersonCard fields. Forces the listview to re-draw it's content.
+     * @param displayFilterPredicate display filter
+     */
+    public void updateDisplayFilter(DisplayFilterPredicate displayFilterPredicate) {
+        this.displayFilterPredicate = displayFilterPredicate;
         this.personListView.refresh();
     }
 
     /**
-     * Custom {@code ListCell} that displays the graphics of a {@code Person} using a {@code PersonCard}.
+     * Custom {@code ListCell} that displays the graphics of a {@code Person} using a {@code
+     * PersonCard}.
      */
     class PersonListViewCell extends ListCell<Person> {
+
         @Override
         protected void updateItem(Person person, boolean empty) {
             super.updateItem(person, empty);
@@ -51,7 +58,8 @@ public class PersonListPanel extends UiPart<Region> {
                 setGraphic(null);
                 setText(null);
             } else {
-                setGraphic(new PersonCard(person, getIndex() + 1, displayFilter).getRoot());
+                setGraphic(
+                        new PersonCard(person, getIndex() + 1, displayFilterPredicate).getRoot());
             }
         }
     }

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -14,7 +14,7 @@
     <columnConstraints>
       <ColumnConstraints hgrow="SOMETIMES" minWidth="10" prefWidth="150" />
     </columnConstraints>
-    <VBox alignment="CENTER_LEFT" minHeight="105" GridPane.columnIndex="0">
+    <VBox alignment="CENTER_LEFT" GridPane.columnIndex="0">
       <padding>
         <Insets top="5" right="5" bottom="5" left="15" />
       </padding>

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -3,22 +3,19 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
-
-import java.nio.file.Path;
-import java.util.function.Predicate;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
 
 import org.junit.jupiter.api.Test;
 
-import javafx.collections.ObservableList;
-import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.model.DisplayFilterPredicate;
 import seedu.address.model.Model;
-import seedu.address.model.ReadOnlyAddressBook;
-import seedu.address.model.ReadOnlyUserPrefs;
-import seedu.address.model.person.Person;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
 
 class FilterCommandTest {
+
+    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void execute_modelUpdated_success() throws Exception {
@@ -29,127 +26,13 @@ class FilterCommandTest {
                 argumentMultimap);
 
         FilterCommand filterCommand = new FilterCommand(displayFilterPredicate);
-        ModelStub modelStub = new ModelStubWithFilter();
 
         // before executing
-        assertNotEquals(modelStub.getDisplayFilter(), displayFilterPredicate);
+        assertNotEquals(model.getDisplayFilter(), displayFilterPredicate);
 
-        filterCommand.execute(modelStub);
+        filterCommand.execute(model);
 
         // after executing
-        assertEquals(modelStub.getDisplayFilter(), displayFilterPredicate);
+        assertEquals(model.getDisplayFilter(), displayFilterPredicate);
     }
-
-    /**
-     * A default model stub that have all of the methods failing.
-     */
-    private class ModelStub implements Model {
-
-        @Override
-        public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyUserPrefs getUserPrefs() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public GuiSettings getGuiSettings() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setGuiSettings(GuiSettings guiSettings) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public Path getAddressBookFilePath() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBookFilePath(Path addressBookFilePath) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void addPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setAddressBook(ReadOnlyAddressBook newData) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public boolean hasPerson(Person person) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void deletePerson(Person target) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void setPerson(Person target, Person editedPerson) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public ObservableList<Person> getFilteredPersonList() {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateFilteredPersonList(Predicate<Person> predicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public void updateDisplayFilter(DisplayFilterPredicate displayFilterPredicate) {
-            throw new AssertionError("This method should not be called.");
-        }
-
-        @Override
-        public DisplayFilterPredicate getDisplayFilter() {
-            throw new AssertionError("This method should not be called.");
-        }
-    }
-
-    /**
-     * A Model stub that implements {@code DisplayFilterPredicate}.
-     */
-    private class ModelStubWithFilter extends FilterCommandTest.ModelStub {
-
-        private DisplayFilterPredicate displayFilterPredicate;
-
-        public ModelStubWithFilter() {
-            displayFilterPredicate = new DisplayFilterPredicate();
-        }
-
-        public ModelStubWithFilter(DisplayFilterPredicate displayFilterPredicate) {
-            this.displayFilterPredicate = displayFilterPredicate;
-        }
-
-        @Override
-        public void updateDisplayFilter(DisplayFilterPredicate displayFilterPredicate) {
-            this.displayFilterPredicate = displayFilterPredicate;
-        }
-
-        @Override
-        public DisplayFilterPredicate getDisplayFilter() {
-            return displayFilterPredicate;
-        }
-    }
-
 }

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -1,84 +1,50 @@
 package seedu.address.logic.commands;
 
-import static java.util.Objects.requireNonNull;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
-import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.testutil.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
 
 import java.nio.file.Path;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.function.Predicate;
 
 import org.junit.jupiter.api.Test;
 
 import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
-import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.AddressBook;
+import seedu.address.logic.parser.ArgumentMultimap;
 import seedu.address.model.DisplayFilterPredicate;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
 import seedu.address.model.person.Person;
-import seedu.address.testutil.PersonBuilder;
 
-public class AddCommandTest {
-
-    @Test
-    public void constructor_nullPerson_throwsNullPointerException() {
-        assertThrows(NullPointerException.class, () -> new AddCommand(null));
-    }
+class FilterCommandTest {
 
     @Test
-    public void execute_personAcceptedByModel_addSuccessful() throws Exception {
-        ModelStubAcceptingPersonAdded modelStub = new ModelStubAcceptingPersonAdded();
-        Person validPerson = new PersonBuilder().build();
+    public void execute_modelUpdated_success() throws Exception {
+        ArgumentMultimap argumentMultimap = new ArgumentMultimap();
+        argumentMultimap.put(PREFIX_ADDRESS, "");
 
-        CommandResult commandResult = new AddCommand(validPerson).execute(modelStub);
+        DisplayFilterPredicate displayFilterPredicate = new DisplayFilterPredicate(
+                argumentMultimap);
 
-        assertEquals(String.format(AddCommand.MESSAGE_SUCCESS, validPerson), commandResult.getFeedbackToUser());
-        assertEquals(Arrays.asList(validPerson), modelStub.personsAdded);
-    }
+        FilterCommand filterCommand = new FilterCommand(displayFilterPredicate);
+        ModelStub modelStub = new ModelStubWithFilter();
 
-    @Test
-    public void execute_duplicatePerson_throwsCommandException() {
-        Person validPerson = new PersonBuilder().build();
-        AddCommand addCommand = new AddCommand(validPerson);
-        ModelStub modelStub = new ModelStubWithPerson(validPerson);
+        // before executing
+        assertNotEquals(modelStub.getDisplayFilter(), displayFilterPredicate);
 
-        assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_PERSON, () -> addCommand.execute(modelStub));
-    }
+        filterCommand.execute(modelStub);
 
-    @Test
-    public void equals() {
-        Person alice = new PersonBuilder().withName("Alice").build();
-        Person bob = new PersonBuilder().withName("Bob").build();
-        AddCommand addAliceCommand = new AddCommand(alice);
-        AddCommand addBobCommand = new AddCommand(bob);
-
-        // same object -> returns true
-        assertTrue(addAliceCommand.equals(addAliceCommand));
-
-        // same values -> returns true
-        AddCommand addAliceCommandCopy = new AddCommand(alice);
-        assertTrue(addAliceCommand.equals(addAliceCommandCopy));
-
-        // different types -> returns false
-        assertFalse(addAliceCommand.equals(1));
-
-        // null -> returns false
-        assertFalse(addAliceCommand.equals(null));
-
-        // different person -> returns false
-        assertFalse(addAliceCommand.equals(addBobCommand));
+        // after executing
+        assertEquals(modelStub.getDisplayFilter(), displayFilterPredicate);
     }
 
     /**
      * A default model stub that have all of the methods failing.
      */
     private class ModelStub implements Model {
+
         @Override
         public void setUserPrefs(ReadOnlyUserPrefs userPrefs) {
             throw new AssertionError("This method should not be called.");
@@ -161,44 +127,28 @@ public class AddCommandTest {
     }
 
     /**
-     * A Model stub that contains a single person.
+     * A Model stub that implements {@code DisplayFilterPredicate}.
      */
-    private class ModelStubWithPerson extends ModelStub {
-        private final Person person;
+    private class ModelStubWithFilter extends FilterCommandTest.ModelStub {
 
-        ModelStubWithPerson(Person person) {
-            requireNonNull(person);
-            this.person = person;
+        private DisplayFilterPredicate displayFilterPredicate;
+
+        public ModelStubWithFilter() {
+            displayFilterPredicate = new DisplayFilterPredicate();
+        }
+
+        public ModelStubWithFilter(DisplayFilterPredicate displayFilterPredicate) {
+            this.displayFilterPredicate = displayFilterPredicate;
         }
 
         @Override
-        public boolean hasPerson(Person person) {
-            requireNonNull(person);
-            return this.person.isSamePerson(person);
-        }
-    }
-
-    /**
-     * A Model stub that always accept the person being added.
-     */
-    private class ModelStubAcceptingPersonAdded extends ModelStub {
-        final ArrayList<Person> personsAdded = new ArrayList<>();
-
-        @Override
-        public boolean hasPerson(Person person) {
-            requireNonNull(person);
-            return personsAdded.stream().anyMatch(person::isSamePerson);
+        public void updateDisplayFilter(DisplayFilterPredicate displayFilterPredicate) {
+            this.displayFilterPredicate = displayFilterPredicate;
         }
 
         @Override
-        public void addPerson(Person person) {
-            requireNonNull(person);
-            personsAdded.add(person);
-        }
-
-        @Override
-        public ReadOnlyAddressBook getAddressBook() {
-            return new AddressBook();
+        public DisplayFilterPredicate getDisplayFilter() {
+            return displayFilterPredicate;
         }
     }
 

--- a/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/FilterCommandTest.java
@@ -15,7 +15,7 @@ import seedu.address.model.UserPrefs;
 
 class FilterCommandTest {
 
-    private Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+    private final Model model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
 
     @Test
     public void execute_modelUpdated_success() throws Exception {
@@ -34,5 +34,37 @@ class FilterCommandTest {
 
         // after executing
         assertEquals(model.getDisplayFilter(), displayFilterPredicate);
+    }
+
+    @Test
+    public void equals() {
+        final ArgumentMultimap addressMultimap = new ArgumentMultimap();
+        addressMultimap.put(PREFIX_ADDRESS, "");
+        final DisplayFilterPredicate addressOnlyPredicate = new DisplayFilterPredicate(
+                addressMultimap);
+        final FilterCommand standardCommand = new FilterCommand(new DisplayFilterPredicate());
+        final FilterCommand addressPredicateCommand = new FilterCommand(addressOnlyPredicate);
+        final FilterCommand dupeAddressPredicateCommand = new FilterCommand(addressOnlyPredicate);
+        final FilterCommand commandWithSameValues = new FilterCommand(new DisplayFilterPredicate());
+
+        // same predicate, default -> returns true
+        assertEquals(commandWithSameValues, standardCommand);
+
+        // same predicate, address -> returns true
+        assertEquals(addressPredicateCommand, dupeAddressPredicateCommand);
+
+        // same object -> returns true
+        assertEquals(standardCommand, standardCommand);
+        assertEquals(addressPredicateCommand, addressPredicateCommand);
+
+        // null -> returns false
+        assertNotEquals(standardCommand, null);
+        assertNotEquals(addressPredicateCommand, null);
+
+        // different command types -> returns false
+        assertNotEquals(new ClearCommand(), standardCommand);
+
+        // different predicate -> returns false
+        assertNotEquals(addressPredicateCommand, standardCommand);
     }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -4,6 +4,9 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
 
@@ -19,10 +22,12 @@ import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterCommand;
 import seedu.address.logic.commands.FindCommand;
 import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.DisplayFilterPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -74,6 +79,20 @@ public class AddressBookParserTest {
         FindCommand command = (FindCommand) parser.parseCommand(
                 FindCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
         assertEquals(new FindCommand(new NameContainsKeywordsPredicate(keywords)), command);
+    }
+
+    @Test
+    public void parseCommand_filter() throws Exception {
+        List<String> keywords = Arrays.asList(PREFIX_ADDRESS.toString(), PREFIX_PHONE.toString(),
+                PREFIX_EMAIL.toString());
+        ArgumentMultimap argumentMultimap = new ArgumentMultimap();
+        argumentMultimap.put(PREFIX_ADDRESS, "");
+        argumentMultimap.put(PREFIX_PHONE, "");
+        argumentMultimap.put(PREFIX_EMAIL, "");
+        DisplayFilterPredicate displayFilterPredicate = new DisplayFilterPredicate(argumentMultimap);
+        FilterCommand command = (FilterCommand) parser.parseCommand(
+                FilterCommand.COMMAND_WORD + " " + keywords.stream().collect(Collectors.joining(" ")));
+        assertEquals(new FilterCommand(displayFilterPredicate), command);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/FilterCommandParserTest.java
@@ -1,0 +1,34 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.FilterCommand;
+import seedu.address.model.DisplayFilterPredicate;
+
+class FilterCommandParserTest {
+
+    private final FilterCommandParser parser = new FilterCommandParser();
+
+    @Test
+    public void parse_emptyArgs_success() {
+        FilterCommand expectedFilterCommand = new FilterCommand(new DisplayFilterPredicate());
+        assertParseSuccess(parser, "", expectedFilterCommand);
+    }
+
+    @Test
+    public void parse_allFields_success() {
+        String arguments =
+                PREFIX_PHONE + " " + PREFIX_EMAIL + " " + PREFIX_ADDRESS + " " + PREFIX_TAG;
+        ArgumentMultimap argumentMultimap = ArgumentTokenizer
+                .tokenize(arguments, PREFIX_PHONE, PREFIX_EMAIL, PREFIX_ADDRESS, PREFIX_TAG);
+        FilterCommand expectedFilterCommand = new FilterCommand(
+                new DisplayFilterPredicate(argumentMultimap));
+        assertParseSuccess(parser, arguments, expectedFilterCommand);
+    }
+}

--- a/src/test/java/seedu/address/model/DisplayFilterPredicateTest.java
+++ b/src/test/java/seedu/address/model/DisplayFilterPredicateTest.java
@@ -1,0 +1,107 @@
+package seedu.address.model;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_ADDRESS;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_EMAIL;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.parser.ArgumentMultimap;
+
+class DisplayFilterPredicateTest {
+
+    @Test
+    public void equals() {
+        ArgumentMultimap argumentMultimap = new ArgumentMultimap();
+        argumentMultimap.put(PREFIX_ADDRESS, "");
+
+        DisplayFilterPredicate first = new DisplayFilterPredicate();
+        DisplayFilterPredicate second = new DisplayFilterPredicate(argumentMultimap);
+        assertNotEquals(second, first);
+
+        ArgumentMultimap argumentMultimapFull = new ArgumentMultimap();
+        argumentMultimap.put(PREFIX_NAME, "");
+        argumentMultimap.put(PREFIX_ADDRESS, "");
+        argumentMultimap.put(PREFIX_EMAIL, "");
+        argumentMultimap.put(PREFIX_TAG, "");
+        argumentMultimap.put(PREFIX_PHONE, "");
+
+        DisplayFilterPredicate third = new DisplayFilterPredicate(new ArgumentMultimap());
+        assertEquals(first, third);
+    }
+
+    @Test
+    public void test_defaultArgs_allTrue() {
+        DisplayFilterPredicate displayFilterPredicate = new DisplayFilterPredicate();
+
+        assertTrue(displayFilterPredicate.test(PREFIX_ADDRESS));
+        assertTrue(displayFilterPredicate.test(PREFIX_NAME));
+        assertTrue(displayFilterPredicate.test(PREFIX_EMAIL));
+        assertTrue(displayFilterPredicate.test(PREFIX_TAG));
+        assertTrue(displayFilterPredicate.test(PREFIX_PHONE));
+    }
+
+    @Test
+    public void test_emptyArgMap_allTrue() {
+        DisplayFilterPredicate displayFilterPredicate = new DisplayFilterPredicate(
+                new ArgumentMultimap());
+
+        assertTrue(displayFilterPredicate.test(PREFIX_ADDRESS));
+        assertTrue(displayFilterPredicate.test(PREFIX_NAME));
+        assertTrue(displayFilterPredicate.test(PREFIX_EMAIL));
+        assertTrue(displayFilterPredicate.test(PREFIX_TAG));
+        assertTrue(displayFilterPredicate.test(PREFIX_PHONE));
+    }
+
+    @Test
+    public void test_argMapNameAlwaysTrue_success() {
+        ArgumentMultimap argumentMultimap = new ArgumentMultimap();
+        argumentMultimap.put(PREFIX_ADDRESS, "");
+        DisplayFilterPredicate displayFilterPredicate = new DisplayFilterPredicate(
+                argumentMultimap);
+
+        assertTrue(displayFilterPredicate.test(PREFIX_NAME));
+        assertTrue(displayFilterPredicate.test(PREFIX_ADDRESS));
+        assertFalse(displayFilterPredicate.test(PREFIX_EMAIL));
+        assertFalse(displayFilterPredicate.test(PREFIX_TAG));
+        assertFalse(displayFilterPredicate.test(PREFIX_PHONE));
+    }
+
+    @Test
+    public void test_argMapNameTrueOthersFalse_success() {
+        ArgumentMultimap argumentMultimap = new ArgumentMultimap();
+        argumentMultimap.put(PREFIX_NAME, "");
+        DisplayFilterPredicate displayFilterPredicate = new DisplayFilterPredicate(
+                argumentMultimap);
+
+        assertTrue(displayFilterPredicate.test(PREFIX_NAME));
+        assertFalse(displayFilterPredicate.test(PREFIX_ADDRESS));
+        assertFalse(displayFilterPredicate.test(PREFIX_EMAIL));
+        assertFalse(displayFilterPredicate.test(PREFIX_TAG));
+        assertFalse(displayFilterPredicate.test(PREFIX_PHONE));
+    }
+
+    @Test
+    public void test_argMapFilledAllTrue_success() {
+        ArgumentMultimap argumentMultimap = new ArgumentMultimap();
+        argumentMultimap.put(PREFIX_NAME, "");
+        argumentMultimap.put(PREFIX_ADDRESS, "");
+        argumentMultimap.put(PREFIX_EMAIL, "");
+        argumentMultimap.put(PREFIX_TAG, "");
+        argumentMultimap.put(PREFIX_PHONE, "");
+        DisplayFilterPredicate displayFilterPredicate = new DisplayFilterPredicate(
+                argumentMultimap);
+
+        assertTrue(displayFilterPredicate.test(PREFIX_ADDRESS));
+        assertTrue(displayFilterPredicate.test(PREFIX_NAME));
+        assertTrue(displayFilterPredicate.test(PREFIX_EMAIL));
+        assertTrue(displayFilterPredicate.test(PREFIX_TAG));
+        assertTrue(displayFilterPredicate.test(PREFIX_PHONE));
+    }
+}

--- a/src/test/java/seedu/address/model/DisplayFilterPredicateTest.java
+++ b/src/test/java/seedu/address/model/DisplayFilterPredicateTest.java
@@ -10,30 +10,58 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PHONE;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_TAG;
 
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import seedu.address.logic.parser.ArgumentMultimap;
 
 class DisplayFilterPredicateTest {
 
+    private ArgumentMultimap addressMultimap;
+    private ArgumentMultimap fullMultimap;
+
+    @BeforeEach
+    public void initializeArguments() {
+        addressMultimap = new ArgumentMultimap();
+        addressMultimap.put(PREFIX_ADDRESS, "");
+
+        fullMultimap = new ArgumentMultimap();
+        fullMultimap.put(PREFIX_NAME, "");
+        fullMultimap.put(PREFIX_ADDRESS, "");
+        fullMultimap.put(PREFIX_EMAIL, "");
+        fullMultimap.put(PREFIX_TAG, "");
+        fullMultimap.put(PREFIX_PHONE, "");
+    }
+
     @Test
-    public void equals() {
-        ArgumentMultimap argumentMultimap = new ArgumentMultimap();
-        argumentMultimap.put(PREFIX_ADDRESS, "");
+    public void test_predicateEqualsCheck_allEquals() {
+        DisplayFilterPredicate emptyArgs = new DisplayFilterPredicate();
+        DisplayFilterPredicate defaultArgs = new DisplayFilterPredicate(new ArgumentMultimap());
+        DisplayFilterPredicate addressArgs = new DisplayFilterPredicate(addressMultimap);
+        DisplayFilterPredicate dupeAddressArgs = new DisplayFilterPredicate(addressMultimap);
+        DisplayFilterPredicate fullArgs = new DisplayFilterPredicate(fullMultimap);
 
-        DisplayFilterPredicate first = new DisplayFilterPredicate();
-        DisplayFilterPredicate second = new DisplayFilterPredicate(argumentMultimap);
-        assertNotEquals(second, first);
+        assertEquals(emptyArgs, defaultArgs);
+        assertEquals(emptyArgs, fullArgs);
+        assertEquals(emptyArgs, defaultArgs);
+        assertEquals(addressArgs, addressArgs);
+        assertEquals(addressArgs, dupeAddressArgs);
+    }
 
-        ArgumentMultimap argumentMultimapFull = new ArgumentMultimap();
-        argumentMultimap.put(PREFIX_NAME, "");
-        argumentMultimap.put(PREFIX_ADDRESS, "");
-        argumentMultimap.put(PREFIX_EMAIL, "");
-        argumentMultimap.put(PREFIX_TAG, "");
-        argumentMultimap.put(PREFIX_PHONE, "");
+    @Test
+    public void test_predicateEqualsCheck_allNotEquals() {
+        DisplayFilterPredicate emptyArgs = new DisplayFilterPredicate();
+        DisplayFilterPredicate addressArgs = new DisplayFilterPredicate(addressMultimap);
+        DisplayFilterPredicate fullArgs = new DisplayFilterPredicate(fullMultimap);
 
-        DisplayFilterPredicate third = new DisplayFilterPredicate(new ArgumentMultimap());
-        assertEquals(first, third);
+        assertNotEquals(emptyArgs, addressArgs);
+        assertNotEquals(addressArgs, fullArgs);
+        assertNotEquals(1, emptyArgs);
+        assertNotEquals(1, addressArgs);
+        assertNotEquals(1, fullArgs);
+        assertNotEquals(null, emptyArgs);
+        assertNotEquals(null, addressArgs);
+        assertNotEquals(null, fullArgs);
     }
 
     @Test


### PR DESCRIPTION
Implementation: Add a new `filter` command to set which items are filtered out.

Name control cannot be filtered out.

`filter` without any arguments will by default show all controls.
`filter a/` will show only the address and name.

Tasks:

- [x] Test cases
- [x] Documentation (DG, UG)
- [x] Check for bugs against new command flag changes

Closes #13 