### PR TITLE
Refactor: Add "alias" command to autocomplete list panel

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -66,5 +66,11 @@ public interface Logic {
      */
     DisplayFilterPredicate getDisplayFilter();
 
+    /**
+     * Gets a filtered list of Autocomplete commands given a "starts-with" value.
+     *
+     * @param value String value to be used as "starts-with" value in filter
+     * @return Returns a filtered ObservableList of commands
+     */
     ObservableList<String> getAutocompleteCommands(String value);
 }

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -113,6 +113,12 @@ public class LogicManager implements Logic {
         return model.getDisplayFilter();
     }
 
+    /**
+     * Gets a filtered list of Autocomplete commands given a "starts-with" value.
+     *
+     * @param value String value to be used as "starts-with" value in filter
+     * @return Returns a filtered ObservableList of commands
+     */
     @Override
     public ObservableList<String> getAutocompleteCommands(String value) {
         List<String> commandList = new ArrayList<>();

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -3,6 +3,7 @@ package seedu.address.logic;
 import java.io.IOException;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.logging.Logger;
 import java.util.stream.Collectors;
@@ -12,6 +13,7 @@ import javafx.collections.ObservableList;
 import seedu.address.commons.core.GuiSettings;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AliasCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.Command;
 import seedu.address.logic.commands.CommandResult;
@@ -123,6 +125,8 @@ public class LogicManager implements Logic {
         commandList.add(FilterCommand.COMMAND_WORD);
         commandList.add(ExitCommand.COMMAND_WORD);
         commandList.add(HelpCommand.COMMAND_WORD);
+        commandList.add(AliasCommand.COMMAND_WORD);
+        Collections.sort(commandList);
 
         if (value == null || value.isEmpty()) {
             return FXCollections.observableList(commandList);

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -113,12 +113,6 @@ public class LogicManager implements Logic {
         return model.getDisplayFilter();
     }
 
-    /**
-     * Gets a filtered list of Autocomplete commands given a "starts-with" value.
-     *
-     * @param value String value to be used as "starts-with" value in filter
-     * @return Returns a filtered ObservableList of commands
-     */
     @Override
     public ObservableList<String> getAutocompleteCommands(String value) {
         List<String> commandList = new ArrayList<>();

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -153,9 +153,10 @@ public class MainWindow extends UiPart<Stage> {
         statusbarPlaceholder.getChildren().add(statusBarFooter.getRoot());
 
         commandBox = new CommandBox(this::executeCommand);
+        // Pre-populates list
+        autocompleteListPanel.updateList(logic.getAutocompleteCommands(""));
         commandBox.setKeyUpCallback((value) -> {
-            logger.info("value entered: " + value);
-            // Update autocomplete list
+            // Update autocomplete list on keyup
             autocompleteListPanel.updateList(logic.getAutocompleteCommands(value));
         });
         commandBoxPlaceholder.getChildren().add(commandBox.getRoot());

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -1,6 +1,7 @@
 package seedu.address.logic;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_PERSON_DISPLAYED_INDEX;
 import static seedu.address.commons.core.Messages.MESSAGE_UNKNOWN_COMMAND;
 import static seedu.address.logic.commands.CommandTestUtil.ADDRESS_DESC_AMY;
@@ -13,7 +14,9 @@ import static seedu.address.testutil.TypicalPersons.AMY;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -111,33 +114,29 @@ public class LogicManagerTest {
     }
 
     @Test
-    public void getAutocompleteCommands_nullParameter() {
-        int testListSize = logic.getAutocompleteCommands(null).size();
-        assertEquals(10, testListSize);
+    public void getAutocompleteCommands_nullParameterReturnsSameAsEmptyParameter() {
+        List<String> nullCommandList = logic.getAutocompleteCommands(null);
+        List<String> emptyCommandList = logic.getAutocompleteCommands("");
+        assertEquals(nullCommandList, emptyCommandList);
     }
 
     @Test
     public void getAutocompleteCommands_existingParameter() {
-        String startsWith = "e";
-        int testListSize = logic.getAutocompleteCommands(startsWith).size();
-        assertEquals(2, testListSize);
+        List<String> commandList = new ArrayList<>();
+        commandList.add(EditCommand.COMMAND_WORD);
+        commandList.add(ExitCommand.COMMAND_WORD);
+        Collections.sort(commandList);
+
+        List<String> testList = logic.getAutocompleteCommands("e");
+        assertEquals(commandList, testList);
     }
 
     @Test
     public void getAutocompleteCommands_testLexicographical() {
         ObservableList<String> testList = logic.getAutocompleteCommands("");
-        Collections.sort(testList);
-
-        assertEquals(AddCommand.COMMAND_WORD, testList.get(0));
-        assertEquals(AliasCommand.COMMAND_WORD, testList.get(1));
-        assertEquals(ClearCommand.COMMAND_WORD, testList.get(2));
-        assertEquals(DeleteCommand.COMMAND_WORD, testList.get(3));
-        assertEquals(EditCommand.COMMAND_WORD, testList.get(4));
-        assertEquals(ExitCommand.COMMAND_WORD, testList.get(5));
-        assertEquals(FilterCommand.COMMAND_WORD, testList.get(6));
-        assertEquals(FindCommand.COMMAND_WORD, testList.get(7));
-        assertEquals(HelpCommand.COMMAND_WORD, testList.get(8));
-        assertEquals(ListCommand.COMMAND_WORD, testList.get(9));
+        for (int i = 0; i < testList.size() - 1; i++) {
+            assertTrue(testList.get(i).compareTo(testList.get(i + 1)) <= 0);
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -27,6 +27,7 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
+
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -105,6 +106,13 @@ public class LogicManagerTest {
     @Test
     public void getFilteredPersonList_modifyList_throwsUnsupportedOperationException() {
         assertThrows(UnsupportedOperationException.class, () -> logic.getFilteredPersonList().remove(0));
+    }
+
+    @Test
+    public void getAutocompleteCommands_returnEmptyList_whiteSpaceParameter() {
+        List<String> whiteSpaceCommandList = logic.getAutocompleteCommands(" ");
+        List<String> emptyCommandList = new ArrayList<>();
+        assertEquals(whiteSpaceCommandList, emptyCommandList);
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -27,7 +27,6 @@ import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
-
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -18,6 +18,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 
+import javafx.collections.ObservableList;
 import seedu.address.logic.commands.AddCommand;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.ListCommand;
@@ -103,7 +104,7 @@ public class LogicManagerTest {
     @Test
     public void getAutocompleteCommands_nullParameter() {
         int testListSize = logic.getAutocompleteCommands(null).size();
-        assertEquals(9, testListSize);
+        assertEquals(10, testListSize);
     }
 
     @Test
@@ -113,7 +114,12 @@ public class LogicManagerTest {
         assertEquals(2, testListSize);
     }
 
-
+    @Test
+    public void getAutocompleteCommands_testLexicographical() {
+        char startingLetter = 'a';
+        ObservableList<String> testList = logic.getAutocompleteCommands("");
+        assertEquals(startingLetter, testList.get(0).charAt(0));
+    }
 
     /**
      * Executes the command and confirms that

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -13,6 +13,7 @@ import static seedu.address.testutil.TypicalPersons.AMY;
 
 import java.io.IOException;
 import java.nio.file.Path;
+import java.util.Collections;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -20,7 +21,15 @@ import org.junit.jupiter.api.io.TempDir;
 
 import javafx.collections.ObservableList;
 import seedu.address.logic.commands.AddCommand;
+import seedu.address.logic.commands.AliasCommand;
+import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.CommandResult;
+import seedu.address.logic.commands.DeleteCommand;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.ExitCommand;
+import seedu.address.logic.commands.FilterCommand;
+import seedu.address.logic.commands.FindCommand;
+import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
@@ -116,9 +125,19 @@ public class LogicManagerTest {
 
     @Test
     public void getAutocompleteCommands_testLexicographical() {
-        char startingLetter = 'a';
         ObservableList<String> testList = logic.getAutocompleteCommands("");
-        assertEquals(startingLetter, testList.get(0).charAt(0));
+        Collections.sort(testList);
+
+        assertEquals(AddCommand.COMMAND_WORD, testList.get(0));
+        assertEquals(AliasCommand.COMMAND_WORD, testList.get(1));
+        assertEquals(ClearCommand.COMMAND_WORD, testList.get(2));
+        assertEquals(DeleteCommand.COMMAND_WORD, testList.get(3));
+        assertEquals(EditCommand.COMMAND_WORD, testList.get(4));
+        assertEquals(ExitCommand.COMMAND_WORD, testList.get(5));
+        assertEquals(FilterCommand.COMMAND_WORD, testList.get(6));
+        assertEquals(FindCommand.COMMAND_WORD, testList.get(7));
+        assertEquals(HelpCommand.COMMAND_WORD, testList.get(8));
+        assertEquals(ListCommand.COMMAND_WORD, testList.get(9));
     }
 
     /**

--- a/src/test/java/seedu/address/logic/LogicManagerTest.java
+++ b/src/test/java/seedu/address/logic/LogicManagerTest.java
@@ -24,15 +24,9 @@ import org.junit.jupiter.api.io.TempDir;
 
 import javafx.collections.ObservableList;
 import seedu.address.logic.commands.AddCommand;
-import seedu.address.logic.commands.AliasCommand;
-import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.CommandResult;
-import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.ExitCommand;
-import seedu.address.logic.commands.FilterCommand;
-import seedu.address.logic.commands.FindCommand;
-import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;


### PR DESCRIPTION
Notable changes:
- Fix #81 Add  "alias" to autocomplete commands 
- Removed extra logging information
- Fix #94 autocomplete commands does not initialize on init.

@yaowei-soc for tests