### PR TITLE
Add codecov.yml to fix CI failures

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -1,0 +1,11 @@
+coverage:
+  status:
+    project:
+      default:
+        # basic
+        target: auto
+        threshold: 5%
+        if_ci_failed: error #success, failure, error, ignore
+    patch:
+      default:
+        if_ci_failed: ignore #success, failure, error, ignore


### PR DESCRIPTION
Should resolve #99

- patch failures should be ignored.
- project treshold is set to 5% and will fail on error